### PR TITLE
Nginx-1.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ You can build RPM with headers-more-module using the official SRPM.
 
 # How to build RPM?
 
-1. Create your feature branch(e.g nginx-1.8.0)
+1. Create your feature branch(e.g nginx-1.8.1)
 2. Update 2 files according to the methods described below
     - nginx.spec.centos6.patch
     - nginx.spec.centos7.patch
@@ -28,15 +28,16 @@ You can build RPM with headers-more-module using the official SRPM.
 ### CentOS6
 
 ```
-$ curl -LO http://nginx.org/packages/centos/6/SRPMS/nginx-1.8.0-1.el6.ngx.src.rpm
-$ rpm2cpio.pl nginx-1.8.0-1.el6.ngx.src.rpm | cpio -idv nginx.spec
+$ curl -LO http://nginx.org/packages/centos/6/SRPMS/nginx-1.8.1-1.el6.ngx.src.rpm
+$ rpm2cpio.pl nginx-1.8.1-1.el6.ngx.src.rpm | cpio -idv nginx.spec
 $ cp nginx.spec nginx.spec.org
 $ patch -p0 < nginx.spec.centos6.patch
-    patching file nginx.spec
-    Hunk #1 FAILED at 59.
-    Hunk #9 FAILED at 345.
+patching file nginx.spec
+Hunk #1 FAILED at 59.
+Hunk #9 FAILED at 346.
+2 out of 9 hunks FAILED -- saving rejects to file nginx.spec.rej
 
-# Modify as below using your favorite editor.
+# Modify `nginx.spec` as below using your favorite editor.
 #   Fix `Release:`
 #   Add `Packager:`
 #   Add your changelog to `%changelog`
@@ -48,15 +49,16 @@ $ diff -u nginx.spec.org nginx.spec >! nginx.spec.centos6.patch
 ### CentOS7
 
 ```
-$ curl -LO http://nginx.org/packages/centos/7/SRPMS/nginx-1.8.0-1.el7.ngx.src.rpm
-$ rpm2cpio.pl nginx-1.8.0-1.el7.ngx.src.rpm | cpio -idv nginx.spec
+$ curl -LO http://nginx.org/packages/centos/7/SRPMS/nginx-1.8.1-1.el7.ngx.src.rpm
+$ rpm2cpio.pl nginx-1.8.1-1.el7.ngx.src.rpm | cpio -idv nginx.spec
 $ cp nginx.spec nginx.spec.org
 $ patch -p0 < nginx.spec.centos7.patch
-    patching file nginx.spec
-    Hunk #1 FAILED at 59.
-    Hunk #9 FAILED at 345.
+patching file nginx.spec
+Hunk #1 FAILED at 59.
+Hunk #9 FAILED at 346.
+2 out of 9 hunks FAILED -- saving rejects to file nginx.spec.rej
 
-# Modify as below using your favorite editor.
+# Modify `nginx.spec` as below using your favorite editor.
 #   Fix `Release:`
 #   Add `Packager:`
 #   Add your changelog to `%changelog`

--- a/nginx.spec.centos6.patch
+++ b/nginx.spec.centos6.patch
@@ -1,9 +1,9 @@
---- nginx.spec.org	2015-04-21 15:34:33.000000000 +0000
-+++ nginx.spec	2015-06-09 09:30:31.000000000 +0000
+--- nginx.spec.org	2016-01-29 16:43:00.000000000 +0900
++++ nginx.spec	2016-01-29 16:48:16.000000000 +0900
 @@ -59,7 +59,8 @@
  Summary: High performance web server
  Name: nginx
- Version: 1.8.0
+ Version: 1.8.1
 -Release: 1%{?dist}.ngx
 +Release: ff1%{?dist}.ngx
 +Packager: feedforce Inc. <socialplus_admin@feedforce.jp>
@@ -14,7 +14,7 @@
  Source8: nginx.service
  Source9: nginx.upgrade.sh
  Source10: nginx.suse.logrotate
-+Source11: headers-more-nginx-module-0.26.tar.gz
++Source11: headers-more-nginx-module-0.29.tar.gz
  
  License: 2-clause BSD-like license
  
@@ -60,7 +60,7 @@
 +        --without-mail_smtp_module \
          --with-debug \
 -        %{?with_spdy:--with-http_spdy_module} \
-+        --add-module=../headers-more-nginx-module-0.26 \
++        --add-module=../headers-more-nginx-module-0.29 \
          --with-cc-opt="%{optflags} $(pcre-config --cflags)" \
          $*
  make %{?_smp_mflags}
@@ -97,7 +97,7 @@
 +        --without-mail_imap_module \
 +        --without-mail_pop3_module \
 +        --without-mail_smtp_module \
-+        --add-module=../headers-more-nginx-module-0.26 \
++        --add-module=../headers-more-nginx-module-0.29 \
          --with-cc-opt="%{optflags} $(pcre-config --cflags)" \
          $*
  make %{?_smp_mflags}
@@ -163,9 +163,9 @@
  fi
  
  %changelog
-+* Tue Jun  9 2015 Shota Miyamoto <miyamoto@feedforce.jp>
-+- 1.8.0 for feedforce
++* Fri Jan 29 2016 Takashi Masuda <masutaka@feedforce.jp>
++- 1.8.1 with Headers More module
 +
- * Tue Apr 21 2015 Sergey Budnevitch <sb@nginx.com>
- - 1.8.0
+ * Tue Jan 26 2016 Konstantin Pavlov <thresh@nginx.com>
+ - 1.8.1
  

--- a/nginx.spec.centos7.patch
+++ b/nginx.spec.centos7.patch
@@ -1,9 +1,9 @@
---- nginx.spec.org	2015-04-21 15:34:33.000000000 +0000
-+++ nginx.spec	2015-06-09 10:31:32.000000000 +0000
+--- nginx.spec.org	2016-01-29 16:59:27.000000000 +0900
++++ nginx.spec	2016-01-29 17:01:52.000000000 +0900
 @@ -59,7 +59,8 @@
  Summary: High performance web server
  Name: nginx
- Version: 1.8.0
+ Version: 1.8.1
 -Release: 1%{?dist}.ngx
 +Release: ff1%{?dist}.ngx
 +Packager: feedforce Inc. <socialplus_admin@feedforce.jp>
@@ -14,7 +14,7 @@
  Source8: nginx.service
  Source9: nginx.upgrade.sh
  Source10: nginx.suse.logrotate
-+Source11: headers-more-nginx-module-0.26.tar.gz
++Source11: headers-more-nginx-module-0.29.tar.gz
  
  License: 2-clause BSD-like license
  
@@ -60,7 +60,7 @@
 +        --without-mail_smtp_module \
          --with-debug \
 -        %{?with_spdy:--with-http_spdy_module} \
-+        --add-module=../headers-more-nginx-module-0.26 \
++        --add-module=../headers-more-nginx-module-0.29 \
          --with-cc-opt="%{optflags} $(pcre-config --cflags)" \
          $*
  make %{?_smp_mflags}
@@ -97,7 +97,7 @@
 +        --without-mail_imap_module \
 +        --without-mail_pop3_module \
 +        --without-mail_smtp_module \
-+        --add-module=../headers-more-nginx-module-0.26 \
++        --add-module=../headers-more-nginx-module-0.29 \
          --with-cc-opt="%{optflags} $(pcre-config --cflags)" \
          $*
  make %{?_smp_mflags}
@@ -163,9 +163,9 @@
  fi
  
  %changelog
-+* Tue Jun  9 2015 Shota Miyamoto <miyamoto@feedforce.jp>
-+- 1.8.0 for feedforce
++* Fri Jan 29 2016 Takashi Masuda <masutaka@feedforce.jp>
++- 1.8.1 with Headers More module
 +
- * Tue Apr 21 2015 Sergey Budnevitch <sb@nginx.com>
- - 1.8.0
+ * Tue Jan 26 2016 Konstantin Pavlov <thresh@nginx.com>
+ - 1.8.1
  


### PR DESCRIPTION
> http://nginx.org/#2016-01-26
> 
> 2016-01-26
> [nginx-1.8.1](http://nginx.org/en/download.html) stable and [nginx-1.9.10](http://nginx.org/en/download.html) mainline versions have been released, with fixes for [vulnerabilities in resolver](http://nginx.org/en/security_advisories.html) (CVE-2016-0742, CVE-2016-0746, CVE-2016-0747).

Security Fix 来てたので rpm 作る。
### 追記

Headers More モジュールが 0.26 から 0.29 に上がってたので一緒に上げた。

https://github.com/openresty/headers-more-nginx-module#changes によると変更履歴は http://openresty.org/#Changes に書いてあるとのことだが、激しく見つけづらいので抜粋する。

> - upgraded HeadersMoreNginxModule to 0.29.
>   - bugfix: changing the built-in header X-Forwarded-For via more_set_input_headers or more_clear_input_headers might not take effect in some parts of the nginx core (like $proxy_add_x_forwarded_for).
> - upgraded HeadersMoreNginxModule to 0.28.
>   - bugfix: fixed errors and warnings with C compilers without variadic macro support.
>   - bugfix: setting (builtin) request headers Upgrade, Depth, Destination, Overwrite, and Date might not take effect in standard nginx modules like ngx_http_proxy and ngx_http_dav.
>   - bugfix: when the response header Content-Type contains parameters like "; charset=utf-8", the -t MIME-List options did not work as expected at all. thanks Joseph Bartels for the report.
>   - bugfix: clearing input headers If-Unmodified-Since, If-Match, and If-None-Match did not clear the builtin "shortcut" fields in ngx_http_headers_in_t which might confuse other nginx modules like ngx_http_not_modified_filter_module. The first header gets "shortcuts" fields since nginx 0.9.2 while the latter two since nginx 1.3.3.

0.27 の変更履歴は見つからなかった。ちなみにソースコードの差分はこちら。
https://github.com/openresty/headers-more-nginx-module/compare/v0.26...v0.27

Staging 環境とかで動かして、http header が意図通りになっていれば良いんじゃないでしょうか...。
