### PR TITLE
Fix deploy job in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,10 @@ references:
           # Required by CircleCI 2.0: https://circleci.com/docs/2.0/custom-images/#required-tools-for-primary-containers
           apk add --no-progress git openssh-client tar gzip ca-certificates
 
+          # Required by .circleci/github-release.sh
+          apk add --no-progress curl go musl-dev
+          echo 'export PATH=$PATH:$HOME/go/bin' >> $BASH_ENV
+
   - &restore_cache
       restore_cache:
         name: Restore cache


### PR DESCRIPTION
## 背景

> > * [ ] master ブランチで `deploy` ジョブの CI が通ること
> 
> CI 自体は成功扱いになったが、`curl` がないというエラーが出ていた。
> 
> > ```
> > + curl -sL -w '%{http_code}\n' https://github.com/feedforce/nginx-headers-more-rpm/releases/tag/1.8.1-ff1 -o /dev/null
> > ./.circleci/github-release.sh: line 1: curl: not found
> > ```
> >
> > https://circleci.com/gh/feedforce/nginx-headers-more-rpm/69
> 
> 別 PR にて直します。
>
> https://github.com/feedforce/nginx-headers-more-rpm/pull/17#issuecomment-416164415

## やったこと

* `.circleci/github-release.sh` で使っている `curl` と `go` をインストールした
* `$ go get github.com/aktau/github-release` でビルド時に必要な `musl-dev` もインストールした

go get でなくビルド済みのバイナリを取ってくることも考えられるが、簡単なやり方で直した。

## マージ条件

軽微な修正なのでセルフマージします。

* [x] 動作確認で問題ないこと

## 動作確認方法

以下の差分を加えて一時的に別ブランチに Push する。

```diff
diff --git a/.circleci/config.yml b/.circleci/config.yml
index e48ee89..3f8bc2c 100644
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,3 @@ workflows:
           requires:
             - centos7
             - centos6
-          filters:
-            branches:
-              only:
-                - master
```

```
$ git checkout -b test-ci
$ git commit -am "test ci"
$ git push -u origin test-ci
```

CircleCI のジョブを確認してエラーなく CI が通っていることを確認する。

> ![image](https://user-images.githubusercontent.com/10208211/44652610-4dc4f500-aa27-11e8-8890-36dc07a4a899.png)
>
> https://circleci.com/gh/feedforce/nginx-headers-more-rpm/74

確認後、GitHub から一時的に Push したブランチを削除しておく。

:warning: 実際にデプロイできるかどうかは動作確認できないので、今後リリースする際に動かなかったら直す感じで。